### PR TITLE
alterando querys para utilizar o campo deleted do DB

### DIFF
--- a/src/be/services/AlternativeService.java
+++ b/src/be/services/AlternativeService.java
@@ -14,7 +14,7 @@ public class AlternativeService {
     public static List<Alternative> getListAlternativeById(int idQuestion) {
         List<Alternative> alternatives = new ArrayList<Alternative>();
 
-        final String query = "SELECT a.alternative, a.rigth_alternative FROM question q INNER JOIN alternative a ON q.id = a.id_question WHERE q.id = ? ";
+        final String query = "SELECT a.alternative, a.rigth_alternative FROM question q INNER JOIN alternative a ON q.id = a.id_question WHERE q.id = ? AND a.deleted = false";
 
         Connection connection = null;
         PreparedStatement statement = null;

--- a/src/be/services/QuestionService.java
+++ b/src/be/services/QuestionService.java
@@ -76,7 +76,7 @@ public class QuestionService {
   public static List<Question> getQuestions() {
     List<Question> questions = new ArrayList<>();
 
-    final String query = "SELECT * FROM question ORDER BY id";
+    final String query = "SELECT * FROM question WHERE deleted = false ORDER BY id";
 
     Connection connection = null;
     Statement statement = null;
@@ -130,7 +130,7 @@ public class QuestionService {
   public static boolean updateQuestion(Question question) {
     final String queryUpdate = "UPDATE question SET type_question = ?, question = ?, deleted = ?  where id = ?";
 
-    final String query2 = "DELETE FROM alternative WHERE id_question = ?";
+    final String query2 = "UPDATE alternative SET deleted = true WHERE id_question = ?";
 
     final String query3 = "INSERT INTO alternative(id_question, alternative, rigth_alternative, deleted) VALUES (?, ?, ?, ?)";
 
@@ -181,8 +181,8 @@ public class QuestionService {
   }
 
   public static boolean deleteQuestion(Question question) {
-    final String query1 = "DELETE FROM alternative WHERE id_question = ?";
-    final String query2 = "DELETE FROM question WHERE id = ?";
+    final String query1 = "UPDATE alternative SET deleted = true WHERE id_question = ?";
+    final String query2 = "UPDATE question SET deleted = true WHERE id = ?";
 
     Connection connection = null;
     PreparedStatement statement = null;


### PR DESCRIPTION
LEIAM ISSO

Eu sugiro esse PR apenas para manter a coerência em nosso DB e segui o que o professor Júlio disse ser boa prática.
Deem uma olhada e aprovem ou reprovem!! 
Está funcionando igual antes, apenas onde tinha "DELETE" foi alterado para "UPDATE" e "SET deleted = true"